### PR TITLE
[Cli] sacloud show xxxコマンド実行時のTypeError

### DIFF
--- a/bin/sacloud.js
+++ b/bin/sacloud.js
@@ -175,6 +175,11 @@ reqs.run(function _callback(err, result, requestedCount, totalCount) {
 		
 		case 'resources':
 			
+			if (body.hasOwnProperty('length') && body.length === 0) {
+				console.log('Response of resources is empty');
+				return;
+			}
+			
 			var h = [];
 			
 			!!body[0].id   && h.push('id');


### PR DESCRIPTION
サーバ未作成の状態でshow系コマンドを実行した際、以下のようなエラーが発生しました

``` sh
$ sacloud show disk
GET https://secure.sakura.ad.jp/cloud/api/cloud/1.0/disk.json?{} -> 200 OK (1/1) ~1.849sec

TypeError: Cannot read property 'id' of undefined
    at _callback (/usr/local/share/npm/lib/node_modules/sacloud/bin/sacloud.js:180:13)
    at _Requests.<anonymous> (/usr/local/share/npm/lib/node_modules/sacloud/lib/sacloud/command.requests.js:521:4)
    at _Request._onReadyStateChangeOnXHR (/usr/local/share/npm/lib/node_modules/sacloud/lib/sacloud/client.request.js:126:4)
    at XMLHttpRequestEventTarget.dispatchEvent (/usr/local/share/npm/lib/node_modules/sacloud/node_modules/xhr2/lib/xhr2.js:64:9)
    at XMLHttpRequest._setReadyState (/usr/local/share/npm/lib/node_modules/sacloud/node_modules/xhr2/lib/xhr2.js:360:12)
    at XMLHttpRequest._onHttpResponseEnd (/usr/local/share/npm/lib/node_modules/sacloud/node_modules/xhr2/lib/xhr2.js:478:12)
    at IncomingMessage.<anonymous> (/usr/local/share/npm/lib/node_modules/sacloud/node_modules/xhr2/lib/xhr2.js:442:22)
    at IncomingMessage.EventEmitter.emit (events.js:117:20)
    at _stream_readable.js:910:16
    at process._tickCallback (node.js:415:13)
```

TypeErrorが出る前にチェックするようにしてみました
