### PR TITLE
[Cli] sacloud copy disk :id to archive が失敗する問題

### DIFF
--- a/lib/sacloud/command.requests.js
+++ b/lib/sacloud/command.requests.js
@@ -393,24 +393,28 @@ var parseArgs = function _parseArgsRequests(args) {
 						r.Name        = res.response[res.responseInfo.key].name;
 						r.Description = 'Copy of `' + res.response[res.responseInfo.key].name + '`';
 						r.Zone        = { ID: res.response[res.responseInfo.key].storage.zone.id };
-						r.Plan        = { ID: res.response[res.responseInfo.key].plan.id };
 						r.SizeMB      = res.response[res.responseInfo.key].sizeMB;
-						r.Connection  = res.response[res.responseInfo.key].connection;
+						
+						if (destResource === 'disk') {
+							r.Plan        = { ID: res.response[res.responseInfo.key].plan.id };
+							r.Connection  = res.response[res.responseInfo.key].connection;
+						}
 					}
 				});
 				
 				var body = {};
 				var r    = {};
+				var destResource = _.last(args);
 				
 				if (resource === 'disk')    r.SourceDisk    = { ID: args[0] };
 				if (resource === 'archive') r.SourceArchive = { ID: args[0] };
 				
-				if (_.last(args) === 'disk')    body.Disk    = r;
-				if (_.last(args) === 'archive') body.Archive = r;
+				if (destResource === 'disk')    body.Disk    = r;
+				if (destResource === 'archive') body.Archive = r;
 				
 				reqs.push({
 					method: 'POST',
-					path  : _.last(args),
+					path  : destResource,
 					body  : body
 				});
 			}


### PR DESCRIPTION
`sacloud copy disk :id to archive` でアーカイブを新規に作成すると `400 Bad Request` エラーで失敗する問題に対する修正です。
アーカイブ作成時には不要な `Plan` 等のオプションを除いています。
### デバッグ出力

```
upsilon(screen)@www18166ui:~/$ sacloud copy disk 112500597440 to archive
（中略）
#Result
{ requestInfo: 
   { time: 1388059244125,
     method: 'POST',
     url: 'https://secure.sakura.ad.jp/cloud/zone/is1a/api/cloud/1.1/archive.json',
     path: 'archive' },
  request: 
   { Archive: 
      { SourceDisk: { ID: '112500597440' },
        Name: 'disk1',
        Description: 'Copy of `disk1`',
        Zone: { ID: 31001 },
        Plan: { ID: 4 },
        SizeMB: 20480,
        Connection: 'virtio' } },
  responseInfo: 
   { time: 1388059247794,
     latency: 3669,
     length: 376,
     serial: 'fedfdfa55bbafe9fde52e075f021653b',
     status: 400,
     statusText: 'Bad Request',
     type: 'resource',
     key: 'is_fatal' },
  response: 
   { is_fatal: true,
     serial: 'fedfdfa55bbafe9fde52e075f021653b',
     status: '400 Bad Request',
     error_code: 'bad_request',
     error_msg: '不適切な要求です。パラメータの指定誤り、入力規則違反です。入力内容をご確認ください' } }
POST https://secure.sakura.ad.jp/cloud/zone/is1a/api/cloud/1.1/archive.json -> 400 Bad Request (2/2) ~3.669sec
Error: 400: Bad Request
```
