### PR TITLE
Support non-bash shells by skipping completion features

### DIFF
--- a/bin/sacloud.js
+++ b/bin/sacloud.js
@@ -14,6 +14,7 @@ var util     = require('util');
  * Initialize
 **/
 var isWindows = (process.platform === 'win32');
+var isBash    = !process.env.SHELL || process.env.SHELL.match(/\/bash$/);
 
 var configFilePath = path.resolve(
 	opt.config ||
@@ -79,7 +80,7 @@ var commander = sacloud.createCommander({
 /**
  * Complete
 **/
-if (!isWindows) commander.complete();
+if (!isWindows && isBash) commander.complete();
 
 /**
  * Info


### PR DESCRIPTION
Required node_module complete assumes bash for shell.
Skip completion features for other shells so that sacloud can be available anyway.